### PR TITLE
Initialize Flask game panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# Prub-2
+# Game Panel
+
+This repository contains a Flask-based panel to manage Dockerized game servers.
+
+## Structure
+
+- `game-panel/backend/` – Flask app for managing game servers.
+- `game-panel/frontend/` – Placeholder for future frontend code.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install -r game-panel/backend/requirements.txt
+   ```
+2. Set the database connection string:
+   ```bash
+   export DATABASE_URI=mysql+pymysql://user:password@localhost/gamepanel
+   ```
+3. Run the application:
+   ```bash
+   python game-panel/backend/app.py
+   ```
+   The app will create the required tables on first run.
+
+## Features
+
+- Create, start, stop, restart and delete game servers using Docker Compose.
+- Basic pages to list servers, view details/logs and create new ones.

--- a/game-panel/backend/app.py
+++ b/game-panel/backend/app.py
@@ -1,0 +1,128 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+import subprocess
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'change_this')
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
+    'DATABASE_URI',
+    'mysql+pymysql://user:password@localhost/gamepanel',
+)
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+BASE_COMPOSE_DIR = os.path.join(os.getcwd(), 'compose', 'game-servers')
+
+
+db = SQLAlchemy(app)
+
+
+class GameServer(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    game_type = db.Column(db.String(50), nullable=False)
+    compose_path = db.Column(db.String(200), nullable=False)
+    status = db.Column(db.String(20), default='stopped')
+    container_id = db.Column(db.String(64))
+
+
+@app.route('/')
+def index():
+    servers = GameServer.query.all()
+    return render_template('index.html', servers=servers)
+
+
+
+
+def _compose_cmd(server, action):
+    cmd = ['docker', 'compose', '-f', server.compose_path]
+    if action == 'start':
+        cmd += ['up', '-d']
+    elif action == 'stop':
+        cmd += ['stop']
+    elif action == 'restart':
+        cmd += ['restart']
+    elif action == 'down':
+        cmd += ['down']
+    subprocess.run(cmd, cwd=os.path.dirname(server.compose_path))
+
+
+@app.route('/servers/<int:server_id>/start')
+def start_server(server_id):
+    server = GameServer.query.get_or_404(server_id)
+    _compose_cmd(server, 'start')
+    server.status = 'running'
+    db.session.commit()
+    return redirect(url_for('index'))
+
+
+@app.route('/servers/<int:server_id>/stop')
+def stop_server(server_id):
+    server = GameServer.query.get_or_404(server_id)
+    _compose_cmd(server, 'stop')
+    server.status = 'stopped'
+    db.session.commit()
+    return redirect(url_for('index'))
+
+
+@app.route('/servers/<int:server_id>/restart')
+def restart_server(server_id):
+    server = GameServer.query.get_or_404(server_id)
+    _compose_cmd(server, 'restart')
+    server.status = 'running'
+    db.session.commit()
+    return redirect(url_for('index'))
+
+
+@app.route('/servers/<int:server_id>/delete')
+def delete_server(server_id):
+    server = GameServer.query.get_or_404(server_id)
+    _compose_cmd(server, 'down')
+    db.session.delete(server)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+
+@app.route('/servers/new', methods=['GET', 'POST'])
+def new_server():
+    if request.method == 'POST':
+        name = request.form['name']
+        game_type = request.form['game_type']
+        server_dir = os.path.join(BASE_COMPOSE_DIR, name)
+        os.makedirs(server_dir, exist_ok=True)
+        compose_path = os.path.join(server_dir, 'docker-compose.yml')
+        with open(compose_path, 'w') as f:
+            f.write(f"version: '3'\nservices:\n  {name}:\n    image: {game_type}\n    container_name: {name}\n")
+        server = GameServer(
+            name=name,
+            game_type=game_type,
+            compose_path=compose_path,
+            status='stopped',
+        )
+        db.session.add(server)
+        db.session.commit()
+        return redirect(url_for('index'))
+    return render_template('new_server.html')
+
+
+@app.route('/servers/<int:server_id>')
+def server_detail(server_id):
+    server = GameServer.query.get_or_404(server_id)
+    logs = ''
+    try:
+        result = subprocess.run(
+            ['docker', 'compose', '-f', server.compose_path, 'logs', '--tail', '20'],
+            cwd=os.path.dirname(server.compose_path),
+            capture_output=True,
+            text=True,
+        )
+        logs = result.stdout
+    except Exception:
+        logs = 'Unable to get logs.'
+    return render_template('detail.html', server=server, logs=logs)
+
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(host='0.0.0.0', port=5000)

--- a/game-panel/backend/requirements.txt
+++ b/game-panel/backend/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+Flask-SQLAlchemy
+pymysql
+docker

--- a/game-panel/backend/templates/detail.html
+++ b/game-panel/backend/templates/detail.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<title>{{ server.name }}</title>
+<h1>{{ server.name }} ({{ server.game_type }})</h1>
+<p>Status: {{ server.status }}</p>
+<pre>{{ logs }}</pre>
+<a href="{{ url_for('index') }}">Back</a>

--- a/game-panel/backend/templates/index.html
+++ b/game-panel/backend/templates/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<title>Servers</title>
+<h1>Game Servers</h1>
+<a href="{{ url_for('new_server') }}">Add Server</a>
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Status</th>
+        <th>Actions</th>
+    </tr>
+    {% for server in servers %}
+    <tr>
+        <td><a href="{{ url_for('server_detail', server_id=server.id) }}">{{ server.name }}</a></td>
+        <td>{{ server.game_type }}</td>
+        <td>{{ server.status }}</td>
+        <td>
+            <a href="{{ url_for('start_server', server_id=server.id) }}">Start</a>
+            <a href="{{ url_for('stop_server', server_id=server.id) }}">Stop</a>
+            <a href="{{ url_for('restart_server', server_id=server.id) }}">Restart</a>
+            <a href="{{ url_for('delete_server', server_id=server.id) }}">Delete</a>
+        </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="4">No servers configured</td></tr>
+    {% endfor %}
+</table>

--- a/game-panel/backend/templates/new_server.html
+++ b/game-panel/backend/templates/new_server.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>New Server</title>
+<h1>Create Server</h1>
+<form method="post">
+    <label>Name <input type="text" name="name"></label><br>
+    <label>Game Type
+        <select name="game_type">
+            <option value="minecraft">Minecraft</option>
+            <option value="ark">Ark</option>
+            <option value="zomboid">Project Zomboid</option>
+        </select>
+    </label><br>
+    <button type="submit">Create</button>
+</form>
+<a href="{{ url_for('index') }}">Back</a>


### PR DESCRIPTION
## Summary
- scaffold Flask backend with login and simple server listing
- add minimal HTML templates
- document how to run the panel
- fix database creation within Flask app context
- expand server management features
- remove login system for now

## Testing
- `python -m py_compile game-panel/backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6864d12f4384832f8702b9461e1af5d4